### PR TITLE
Ensure timeout is required for response generation

### DIFF
--- a/app/services/ai/response_generation_service.rb
+++ b/app/services/ai/response_generation_service.rb
@@ -1,3 +1,4 @@
+require 'timeout'
 require "openai"
 
 class Ai::ResponseGenerationService


### PR DESCRIPTION
## Summary
- require 'timeout' so `Timeout` constant is available when loading service directly

## Testing
- `ruby -I. -e "module Ai; end; require './app/services/ai/response_generation_service'; puts Timeout.class"`
- `bundle exec rspec` *(fails: command not found)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bd70dabd58832497d3d76f8aeefbb2