### PR TITLE
Handle missing AI responses before citation creation

### DIFF
--- a/app/services/ai/response_generation_service.rb
+++ b/app/services/ai/response_generation_service.rb
@@ -24,12 +24,18 @@ class Ai::ResponseGenerationService
     
     # Generate response
     response_data = generate_ai_response(context)
-    
-    # Create citations
-    create_citations(response_data[:citations]) if response_data[:citations].any?
-    
+
+    unless response_data.present? && response_data[:response].present?
+      error_message = "AI response missing or malformed"
+      Rails.logger.error "[ResponseGenerationService] #{error_message}"
+      return { error: error_message }
+    end
+
+    # Create citations only if we have response data
+    create_citations(response_data[:citations]) if response_data.present? && response_data[:citations]&.any?
+
     Rails.logger.info "[ResponseGenerationService] Completed successfully"
-    
+
     response_data
     
   rescue StandardError => e


### PR DESCRIPTION
## Summary
- Validate AI response data before attempting to create citations
- Return structured error when AI response is missing or malformed
- Guard citation creation so it only runs when response data is present

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Ruby version 3.4.5 required but 3.2.3 installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7134dbd883248e3cf95f9447ce1a