### PR TITLE
Refactor OpenAI client initialization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ gem "bootsnap", require: false
 
 # AI and Vector Search
 gem 'neighbor'
-gem 'openai', '~> 0.22.0'
 gem "ruby-openai"
 gem 'faraday'
 gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,8 +267,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
-    openai (0.22.0)
-      connection_pool
     os (1.1.4)
     parallel (1.27.0)
     parser (3.3.9.0)
@@ -513,7 +511,6 @@ DEPENDENCIES
   mechanize
   neighbor
   nokogiri
-  openai (~> 0.22.0)
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/jobs/ai_response_generation_job.rb
+++ b/app/jobs/ai_response_generation_job.rb
@@ -8,7 +8,7 @@ class AiResponseGenerationJob < ApplicationJob
 
     Rails.logger.info "[AiResponseGenerationJob] Starting AI generation for search #{search.id}"
 
-    unless $openai_client
+    unless Rails.application.config.x.openai_client
       Rails.logger.error "[AiResponseGenerationJob] OpenAI client not initialized!"
       search.update!(status: :failed, error_message: "OpenAI client not configured")
       SearchesController.broadcast_status_update(search.id) rescue nil

--- a/app/services/ai/embedding_service.rb
+++ b/app/services/ai/embedding_service.rb
@@ -41,7 +41,7 @@ class Ai::EmbeddingService
   def generate_single_embedding(text)
     validate_client!
     
-    response = $openai_client.embeddings(
+    response = openai_client.embeddings(
       parameters: {
         model: MODEL,
         input: text,
@@ -119,7 +119,7 @@ class Ai::EmbeddingService
   end
   
   def validate_client!
-    if $openai_client.nil?
+    if openai_client.nil?
       raise EmbeddingError, "OpenAI client not initialized"
     end
   end
@@ -128,6 +128,10 @@ class Ai::EmbeddingService
     unless embedding.is_a?(Array) && embedding.length == DIMENSIONS
       raise EmbeddingError, "Invalid embedding format"
     end
+  end
+
+  def openai_client
+    Rails.application.config.x.openai_client
   end
   
   def handle_api_error(error)

--- a/app/services/ai/response_generation_service.rb
+++ b/app/services/ai/response_generation_service.rb
@@ -41,7 +41,7 @@ class Ai::ResponseGenerationService
   private
   
   def validate_prerequisites!
-    unless $openai_client
+    unless openai_client
       raise "OpenAI client not configured"
     end
     
@@ -123,7 +123,7 @@ class Ai::ResponseGenerationService
     response = nil
     begin
       Timeout.timeout(60) do
-        response = $openai_client.chat(
+        response = openai_client.chat(
           parameters: {
             model: MODEL,
             messages: messages,
@@ -306,9 +306,13 @@ class Ai::ResponseGenerationService
   rescue => e
     Rails.logger.error "[ResponseGenerationService] Citation creation failed: #{e.message}"
   end
-  
+
   def estimate_tokens(text)
     # Rough estimation: ~4 characters per token
     (text.length / 4.0).ceil
+  end
+
+  def openai_client
+    Rails.application.config.x.openai_client
   end
 end

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,10 +1,9 @@
 require "openai"
 
-  Rails.application.config.after_initialize do
-  if ENV['OPENAI_API_KEY'].present?
-  $openai_client = OpenAI::Client.new(api_key: ENV['OPENAI_API_KEY'])
-  else
-    Rails.logger.warn "OpenAI client not initialized: OPENAI_API_KEY missing"
-    $openai_client = nil
-  end
+api_key = ENV["OPENAI_API_KEY"]
+if api_key.blank?
+  raise "OpenAI client not initialized: OPENAI_API_KEY missing"
 end
+
+Rails.application.config.x.openai_client = OpenAI::Client.new(access_token: api_key)
+


### PR DESCRIPTION
## Summary
- remove redundant `openai` gem
- initialize one shared `OpenAI::Client` and expose via Rails config
- refactor AI services and jobs to use the shared client

## Testing
- `bundle install` *(fails: Ruby version mismatch)*
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd714408e88324aeaa34f8fd87a5b0