### PR TITLE
Log OpenAI responses and return structured errors

### DIFF
--- a/app/jobs/ai_response_generation_job.rb
+++ b/app/jobs/ai_response_generation_job.rb
@@ -29,6 +29,8 @@ class AiResponseGenerationJob < ApplicationJob
       )
       SearchesController.broadcast_ai_response_ready(search.id)
       Rails.logger.info "[AiResponseGenerationJob] Successfully completed AI generation for search #{search.id}"
+    elsif data && data[:error]
+      handle_failure(search, data[:error])
     else
       handle_failure(search, "AI response generation failed to produce content.")
     end


### PR DESCRIPTION
## Summary
- Log raw OpenAI API responses with search ID, token count, and model
- Return structured error hashes from `generate_ai_response` and `generate_response`
- Surface specific error messages in `AiResponseGenerationJob`

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7154b1588324934065f5d2a63857