### PR TITLE
Improve AI response reliability and search performance

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -76,7 +76,7 @@ class SearchesController < ApplicationController
   def retry_ai_generation
     @search = Search.find(params[:id])
     
-    if @search.scraping? || @search.failed?
+    if @search.scraping? || @search.retryable? || @search.failed?
       documents_with_content = @search.documents.where.not(content: [nil, ''])
       content_count = documents_with_content.count
     
@@ -91,7 +91,7 @@ class SearchesController < ApplicationController
         redirect_to @search, alert: 'Cannot generate AI response: No content has been successfully scraped.'
       end
     else
-      redirect_to @search, alert: "AI response can only be retried for 'scraping' or 'failed' searches."
+      redirect_to @search, alert: "AI response can only be retried for 'scraping' or 'retryable' searches."
     end
   end
 

--- a/app/jobs/search_processing_job.rb
+++ b/app/jobs/search_processing_job.rb
@@ -66,7 +66,7 @@ class SearchProcessingJob < ApplicationJob
       service = Search::WebSearchService.new
     end
     
-    results = service.search(@search.query, num_results: 10)
+    results = service.search(@search.query, num_results: 5)
 
     @metrics[:steps_completed] << :web_search
     @metrics[:search_results_count] = results.length

--- a/app/jobs/web_scraping_job.rb
+++ b/app/jobs/web_scraping_job.rb
@@ -29,9 +29,6 @@ class WebScrapingJob < ApplicationJob
     broadcast_scraping_progress(scraped_data)
 
     if scraped_data[:success]
-      # Generate embeddings if content available
-      generate_embeddings if @document.content_available?
-      
       # Update search result relevance
       update_relevance_score
     end
@@ -72,12 +69,6 @@ class WebScrapingJob < ApplicationJob
     end
     
     @document.save!
-  end
-  
-  def generate_embeddings
-    Rails.logger.info "[WebScrapingJob] Queueing embedding generation for document #{@document.id}"
-    EmbeddingGenerationJob.perform_later(@document.id)
-    @metrics[:embedding_queued] = true
   end
   
   def update_relevance_score

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -5,7 +5,7 @@ class Search < ApplicationRecord
   
   has_neighbors :query_embedding, dimensions: 1536
   
-  enum :status, { pending: 0, processing: 1, completed: 2, failed: 3, scraping: 4 }, default: :pending
+  enum :status, { pending: 0, processing: 1, completed: 2, failed: 3, scraping: 4, retryable: 5 }, default: :pending
   
   validates :query, presence: true, length: { minimum: 1, maximum: 1000 }
   validates :goal, length: { maximum: 500 }, allow_blank: true

--- a/app/services/scraping/content_scraper_service.rb
+++ b/app/services/scraping/content_scraper_service.rb
@@ -3,7 +3,7 @@ class Scraping::ContentScraperService
   require 'readability'
   require 'timeout'
   
-  TIMEOUT_SECONDS = 15
+  TIMEOUT_SECONDS = 10
   MIN_CONTENT_LENGTH = 50
   MAX_CONTENT_LENGTH = 50_000
 

--- a/app/services/search/web_search_service.rb
+++ b/app/services/search/web_search_service.rb
@@ -13,7 +13,7 @@ class Search::WebSearchService
     @api_key = ENV['SERPAPI_KEY']
   end
 
-  def search(query, num_results: 10)
+  def search(query, num_results: 5)
     validate_api_key!
     
   Rails.logger.info "[WebSearchService] Searching for: #{query}"

--- a/app/views/searches/_status.html.erb
+++ b/app/views/searches/_status.html.erb
@@ -21,6 +21,18 @@
             Found <%= search.search_results.count %> relevant sources
           </p>
         </div>
+      <% elsif search.retryable? %>
+        <div class="rounded-full h-5 w-5 bg-yellow-500 flex items-center justify-center">
+          <svg class="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900" data-progress-target="status">AI response failed</h3>
+          <p class="text-sm text-gray-600">
+            <%= search.error_message || "AI response generation failed. You can retry." %>
+          </p>
+        </div>
       <% elsif search.failed? %>
         <div class="rounded-full h-5 w-5 bg-red-500 flex items-center justify-center">
           <svg class="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -84,12 +96,12 @@
     </div>
   <% end %>
 
-  <% if search.failed? && search.documents.where.not(content: [nil, '']).exists? %>
+  <% if search.retryable? %>
     <div class="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-md">
       <p class="text-sm text-yellow-800">
         Some content was gathered before the error occurred. You can try to
-        <%= link_to 'force AI response generation', retry_ai_generation_search_path(search), 
-        data: { turbo_method: :post }, 
+        <%= link_to 'force AI response generation', retry_ai_generation_search_path(search),
+        data: { turbo_method: :post },
          class: "font-semibold underline hover:text-yellow-900" %>.
       </p>
     </div>

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -5,7 +5,7 @@ default: &default
   workers:
     - queues: "*"
       threads: 3
-      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 2) %>
       polling_interval: 0.1
 
 development:

--- a/spec/jobs/ai_response_generation_job_spec.rb
+++ b/spec/jobs/ai_response_generation_job_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe AiResponseGenerationJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:search) { create(:search, status: :scraping) }
+
+  before do
+    allow(Ai::ResponseGenerationService).to receive(:new).and_return(service)
+  end
+
+  context 'when generation succeeds' do
+    let(:service) { instance_double(Ai::ResponseGenerationService, generate_response: {response: 'Hello', follow_up_questions: []}) }
+
+    it 'completes the search and queues embeddings' do
+      doc = create(:document, content: 'abcde', search_results: [build(:search_result, search: search)])
+      expect_any_instance_of(Document).to receive(:generate_embedding!).at_least(:once)
+      perform_enqueued_jobs { described_class.perform_now(search.id) }
+      search.reload
+      expect(search).to be_completed
+      expect(search.ai_response).to eq('Hello')
+    end
+  end
+
+  context 'when generation returns error' do
+    let(:service) { instance_double(Ai::ResponseGenerationService, generate_response: {error: 'failure'}) }
+
+    it 'marks search as retryable with error message' do
+      described_class.perform_now(search.id)
+      search.reload
+      expect(search).to be_retryable
+      expect(search.error_message).to eq('failure')
+    end
+  end
+
+  context 'when insufficient sources' do
+    let(:service) do
+      instance_double(Ai::ResponseGenerationService).tap do |s|
+        allow(s).to receive(:generate_response).and_raise(Ai::ResponseGenerationService::InsufficientSourcesError, 'too few')
+      end
+    end
+
+    it 'marks search as failed with message' do
+      described_class.perform_now(search.id)
+      search.reload
+      expect(search).to be_failed
+      expect(search.error_message).to eq('too few')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,15 @@
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../config/environment', __dir__)
+abort('Rails environment is running in production mode!') if Rails.env.production?
+require 'rspec/rails'
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
+ActiveRecord::Migration.maintain_test_schema!
+
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.use_transactional_fixtures = true
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/services/ai/response_generation_service_spec.rb
+++ b/spec/services/ai/response_generation_service_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Ai::ResponseGenerationService, type: :service do
+  let(:search) { create(:search, status: :scraping) }
+
+  before do
+    Rails.application.config.x.openai_client = openai_client
+  end
+
+  describe '#generate_response' do
+    context 'when OpenAI returns empty content' do
+      let(:openai_client) do
+        instance_double(OpenAI::Client, chat: {'choices' => [{'message' => {'content' => ''}}]})
+      end
+
+      before do
+        create(:document, content: 'abcde', search_results: [build(:search_result, search: search)])
+      end
+
+      it 'returns an empty response error' do
+        result = described_class.new(search).generate_response
+        expect(result).to eq(error: 'Empty response from OpenAI')
+      end
+    end
+
+    context 'when OpenAI times out' do
+      let(:openai_client) do
+        instance_double(OpenAI::Client)
+      end
+
+      before do
+        allow(openai_client).to receive(:chat).and_raise(Timeout::Error)
+        create(:document, content: 'abcde', search_results: [build(:search_result, search: search)])
+      end
+
+      it 'retries and returns timeout error' do
+        service = described_class.new(search)
+        expect(openai_client).to receive(:chat).exactly(3).times
+        result = service.generate_response
+        expect(result).to eq(error: 'OpenAI response timed out after 60s')
+      end
+    end
+
+    context 'when OpenAI client is missing' do
+      let(:openai_client) { nil }
+
+      it 'returns configuration error' do
+        result = described_class.new(search).generate_response
+        expect(result).to eq(error: 'OpenAI client not configured')
+      end
+    end
+
+    context 'with insufficient sources' do
+      let(:openai_client) { instance_double(OpenAI::Client) }
+
+      it 'raises InsufficientSourcesError' do
+        expect {
+          described_class.new(search).generate_response
+        }.to raise_error(Ai::ResponseGenerationService::InsufficientSourcesError)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
## Summary
- Add detailed error handling and retryable status for AI response generation
- Trigger AI generation earlier, speed up scraping and limit results for faster searches
- Defer embeddings, shorten scraping timeouts, and improve logging with new tests

## Testing
- ⚠️ `bundle install` *(Ruby version mismatch: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.5)*
- ⚠️ `bundle exec rspec` *(bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a7277b88324b30aa2cc23f41f6d