### PR TITLE
Add retry prompt to AI response view for retryable searches

### DIFF
--- a/app/views/searches/_ai_response.html.erb
+++ b/app/views/searches/_ai_response.html.erb
@@ -26,6 +26,9 @@
       🕒 Gathering information from sources...
     <% elsif search&.processing? %>
       🤖 AI response is being generated... Please check back in a moment.
+    <% elsif search&.retryable? %>
+      ❌ AI response generation failed.
+      <%= link_to 'Retry AI generation', retry_ai_generation_search_path(search), data: { turbo_method: :post }, class: 'text-blue-600 underline hover:text-blue-800' %>
     <% elsif search&.failed? %>
       ❌ Failed to generate response. Please try again.
     <% else %>


### PR DESCRIPTION
## Summary
- show retry failure message and retry link when AI response generation can be retried

## Testing
- `bundle exec rspec` *(fails: bundler: command not found; bundle install requires Ruby 3.4.5 but found 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaa0cbc588324800da2497834e826