### PR TITLE
Handle OpenAI error responses

### DIFF
--- a/app/jobs/ai_response_generation_job.rb
+++ b/app/jobs/ai_response_generation_job.rb
@@ -40,6 +40,7 @@ class AiResponseGenerationJob < ApplicationJob
       Rails.logger.info "[AiResponseGenerationJob] Successfully completed AI generation for search #{search.id}"
     else
       error_msg = data[:error] || "AI response generation failed to produce content."
+      search.update!(error_message: error_msg)
       handle_failure(search, error_msg, retryable: true)
     end
   rescue Ai::ResponseGenerationService::InsufficientSourcesError => e

--- a/app/services/ai/response_generation_service.rb
+++ b/app/services/ai/response_generation_service.rb
@@ -163,6 +163,12 @@ class Ai::ResponseGenerationService
       end
     end
 
+    if response.is_a?(Hash) && response["error"]
+      error_msg = response.dig("error", "message") || "OpenAI API error"
+      Rails.logger.error "[ResponseGenerationService] OpenAI API returned error (#{context_info}): #{error_msg}"
+      return { error: error_msg }
+    end
+
     raw_content = response.dig('choices', 0, 'message', 'content')
     return { error: 'Empty response from OpenAI' } if raw_content.blank?
 

--- a/app/views/searches/_status.html.erb
+++ b/app/views/searches/_status.html.erb
@@ -30,7 +30,7 @@
         <div>
           <h3 class="text-lg font-semibold text-gray-900" data-progress-target="status">AI response failed</h3>
           <p class="text-sm text-gray-600">
-            <%= search.error_message || "AI response generation failed. You can retry." %>
+            <%= search.error_message.presence || "AI response generation failed. You can retry." %>
           </p>
         </div>
       <% elsif search.failed? %>
@@ -42,7 +42,7 @@
         <div>
           <h3 class="text-lg font-semibold text-gray-900" data-progress-target="status">Search failed</h3>
           <p class="text-sm text-gray-600">
-            <%= search.error_message || "Something went wrong. Please try again." %>
+            <%= search.error_message.presence || "Something went wrong. Please try again." %>
           </p>
         </div>
       <% elsif search.scraping? %>

--- a/spec/services/ai/response_generation_service_spec.rb
+++ b/spec/services/ai/response_generation_service_spec.rb
@@ -41,6 +41,21 @@ RSpec.describe Ai::ResponseGenerationService, type: :service do
       end
     end
 
+    context 'when OpenAI returns an error response' do
+      let(:openai_client) do
+        instance_double(OpenAI::Client, chat: { 'error' => { 'message' => 'bad request' } })
+      end
+
+      before do
+        create(:document, content: 'abcde', search_results: [build(:search_result, search: search)])
+      end
+
+      it 'propagates the error message' do
+        result = described_class.new(search).generate_response
+        expect(result).to eq(error: 'bad request')
+      end
+    end
+
     context 'when OpenAI client is missing' do
       let(:openai_client) { nil }
 


### PR DESCRIPTION
## Summary
- Capture and surface error responses from OpenAI
- Persist AI generation errors on the search record
- Show error messages for failed and retryable searches

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.5)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_68bda9efa5308324864ce55d9c78f947