### PR TITLE
Add logging for search status broadcasts and stream errors

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -247,6 +247,7 @@ class SearchesController < ApplicationController
 
   def self.broadcast_status_update(search_id)
     search = Search.find(search_id)
+    Rails.logger.info "[SearchesController] Broadcasting status update for search #{search.id}"
     Turbo::StreamsChannel.broadcast_replace_to(
       "search_#{search.id}",
       target: "search_status",                 # match _status.html.erb container

--- a/app/javascript/controllers/search_updates_controller.js
+++ b/app/javascript/controllers/search_updates_controller.js
@@ -24,10 +24,16 @@ export default class extends Controller {
 
     this.eventSource = new EventSource(streamUrl)
 
+    this.eventSource.onopen = this.handleOpen.bind(this)
     this.eventSource.onmessage = this.handleMessage.bind(this)
     this.eventSource.onerror = this.handleError.bind(this)
 
     console.log(`Connected to search stream: ${streamUrl}`)
+  }
+
+  // Successfully opened connection
+  handleOpen(event) {
+    console.log('Search stream connection opened', event)
   }
 
   // Disconnect from stream
@@ -64,7 +70,11 @@ export default class extends Controller {
 
   // Handle stream errors
   handleError(event) {
-    console.error('Search stream error:', event)
+    if (event?.target?.readyState === EventSource.CLOSED) {
+      console.error('Search stream connection closed', event)
+    } else {
+      console.error('Search stream error:', event)
+    }
 
     // Attempt to reconnect after a delay
     setTimeout(() => {

--- a/app/jobs/ai_response_generation_job.rb
+++ b/app/jobs/ai_response_generation_job.rb
@@ -31,6 +31,8 @@ class AiResponseGenerationJob < ApplicationJob
         completed_at: Time.current
       )
 
+      SearchesController.broadcast_status_update(search.id)
+
       # Defer embedding generation until after response is ready
       search.documents.with_content.find_each do |doc|
         doc.generate_embedding!


### PR DESCRIPTION
## Summary
- add detailed EventSource connection and error logging to `search_updates_controller.js`
- log each search status broadcast and trigger status refresh after AI response job completes

## Testing
- `ruby bin/jobs` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.5)*
- `bundle exec rake test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.5)*
- `bundle exec rubocop` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaa15d32083249480e8e9d114027b