### PR TITLE
Handle blank AI responses with fallback and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## Background jobs
+
+Start SolidQueue workers from the project root so relative paths resolve correctly and ensure required environment variables are set:
+
+```
+OPENAI_API_KEY=your_key SERPAPI_KEY=your_key bin/jobs start
+```
+
+Use `bin/rails solid_queue:health` to display worker heartbeats and pending jobs.

--- a/lib/tasks/solid_queue.rake
+++ b/lib/tasks/solid_queue.rake
@@ -1,0 +1,15 @@
+namespace :solid_queue do
+  desc "Display SolidQueue process heartbeats and pending jobs by queue"
+  task health: :environment do
+    puts "Processes:" 
+    SolidQueue::Process.all.each do |proc|
+      puts " - #{proc.id} last_heartbeat: #{proc.last_heartbeat_at}"
+    end
+
+    puts "Pending jobs:"
+    SolidQueue::Job.group(:queue_name).count.each do |queue, count|
+      puts " - #{queue}: #{count}"
+    end
+  end
+end
+

--- a/spec/jobs/ai_response_generation_job_spec.rb
+++ b/spec/jobs/ai_response_generation_job_spec.rb
@@ -47,4 +47,15 @@ RSpec.describe AiResponseGenerationJob, type: :job do
       expect(search.error_message).to eq('too few')
     end
   end
+
+  context 'when generation returns blank response' do
+    let(:service) { instance_double(Ai::ResponseGenerationService, generate_response: {response: ''}) }
+
+    it 'marks search as retryable with default message' do
+      described_class.perform_now(search.id)
+      search.reload
+      expect(search).to be_retryable
+      expect(search.error_message).to eq('Model returned empty content; retrying might succeed')
+    end
+  end
 end

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Searches", type: :request do
       AiResponseGenerationJob.perform_now(search.id)
 
       search.reload
-      expect(search.status).to eq("scraping") # Should not be completed
+      expect(search.status).to eq("retryable")
       expect(search.ai_response).to be_nil
     end
   end

--- a/spec/services/ai/response_generation_service_spec.rb
+++ b/spec/services/ai/response_generation_service_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe Ai::ResponseGenerationService, type: :service do
         create(:document, content: 'abcde', search_results: [build(:search_result, search: search)])
       end
 
-      it 'returns an empty response error' do
+      it 'returns a fallback response with citations' do
         result = described_class.new(search).generate_response
-        expect(result).to eq(error: 'Empty response from OpenAI')
+        expect(result[:response]).to include('[1]')
+        expect(result[:follow_up_questions].length).to eq(3)
       end
     end
 


### PR DESCRIPTION
## Summary
- Log messages and raw OpenAI body when AI returns blank content
- Fallback to source-based summary and mark searches retryable
- Add SolidQueue health rake task and document worker startup

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68be8e7eed9083248015eb94bf982487