### PR TITLE
Use dotenv for OpenAI API key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'vcr'
   gem 'webmock'
-  gem 'dotenv-rails'  # Add this line
+  gem 'dotenv-rails'
 end
 
 

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,9 +1,11 @@
 require "openai"
 
-api_key = ENV["OPENAI_API_KEY"]
+api_key = Rails.application.credentials.openai_api_key.presence ||
+          ENV["OPENAI_API_KEY"].presence
+
 if api_key.blank?
-  raise "OpenAI client not initialized: OPENAI_API_KEY missing"
+  Rails.logger.error "[OpenAI] OPENAI_API_KEY missing – AI responses will fail"
+  Rails.application.config.x.openai_client = nil
+else
+  Rails.application.config.x.openai_client = OpenAI::Client.new(access_token: api_key)
 end
-
-Rails.application.config.x.openai_client = OpenAI::Client.new(access_token: api_key)
-


### PR DESCRIPTION
## Summary
- Load dotenv in development and test for environment-based secrets
- Use credentials or OPENAI_API_KEY env var to build OpenAI client and log when missing

## Testing
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.5)*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68beef062a748324adad006b2a6b2916