### PR TITLE
feat: tune search results and timeout

### DIFF
--- a/app/jobs/search_processing_job.rb
+++ b/app/jobs/search_processing_job.rb
@@ -66,7 +66,9 @@ class SearchProcessingJob < ApplicationJob
       service = Search::WebSearchService.new
     end
     
-    results = service.search(@search.query, num_results: 5)
+    # Fetch a slightly larger set of results to improve coverage while
+    # still keeping scraping time reasonable
+    results = service.search(@search.query, num_results: 8)
 
     @metrics[:steps_completed] << :web_search
     @metrics[:search_results_count] = results.length

--- a/app/services/ai/response_generation_service.rb
+++ b/app/services/ai/response_generation_service.rb
@@ -127,9 +127,11 @@ class Ai::ResponseGenerationService
 
     response = nil
     attempts = 0
+    timeout_seconds = 60
+
     begin
       attempts += 1
-      Timeout.timeout(60) do
+      Timeout.timeout(timeout_seconds) do
         response = openai_client.chat(
           parameters: {
             model: MODEL,
@@ -145,10 +147,11 @@ class Ai::ResponseGenerationService
     rescue Timeout::Error => e
       Rails.logger.error "[ResponseGenerationService] OpenAI timeout (#{context_info}): #{e.message}"
       if attempts <= MAX_RETRIES
+        timeout_seconds = 90
         sleep(2 ** attempts)
         retry
       else
-        return { error: "OpenAI response timed out after 60s" }
+        return { error: "OpenAI response timed out after #{timeout_seconds}s" }
       end
     rescue StandardError => e
       Rails.logger.error "[ResponseGenerationService] OpenAI API error (#{context_info}): #{e.message}"

--- a/app/services/search/web_search_service.rb
+++ b/app/services/search/web_search_service.rb
@@ -13,7 +13,9 @@ class Search::WebSearchService
     @api_key = ENV['SERPAPI_KEY']
   end
 
-  def search(query, num_results: 5)
+  # Default to a slightly higher result count for a balance between
+  # coverage and scraping speed
+  def search(query, num_results: 8)
     validate_api_key!
     
   Rails.logger.info "[WebSearchService] Searching for: #{query}"


### PR DESCRIPTION
## Summary
- request more results per search to improve coverage while maintaining speed
- expand web search service default result count
- extend AI response timeout to 90s after initial timeouts

## Testing
- `bundle exec rspec` *(fails: bundler could not install due to Ruby version 3.2.3 vs 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68beef38ff40832494ebacf430a639cc