### PR TITLE
Replace SSE with Turbo Streams and broadcast updates

### DIFF
--- a/app/javascript/controllers/search_updates_controller.js
+++ b/app/javascript/controllers/search_updates_controller.js
@@ -1,182 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
 
 // Connects to data-controller="search-updates"
 export default class extends Controller {
   static targets = ["status", "results", "aiResponse"]
-  static values = {
-    searchId: String,
-    streamUrl: String
-  }
 
-  connect() {
-    this.connectToStream()
-  }
-
-  disconnect() {
-    this.disconnectFromStream()
-  }
-
-  // Connect to Server-Sent Events stream
-  connectToStream() {
-    if (!this.hasSearchIdValue) return
-
-    const streamUrl = this.streamUrlValue || `/searches/${this.searchIdValue}/stream_status`
-
-    this.eventSource = new EventSource(streamUrl)
-
-    this.eventSource.onopen = this.handleOpen.bind(this)
-    this.eventSource.onmessage = this.handleMessage.bind(this)
-    this.eventSource.onerror = this.handleError.bind(this)
-
-    console.log(`Connected to search stream: ${streamUrl}`)
-  }
-
-  // Successfully opened connection
-  handleOpen(event) {
-    console.log('Search stream connection opened', event)
-  }
-
-  // Disconnect from stream
-  disconnectFromStream() {
-    if (this.eventSource) {
-      this.eventSource.close()
-      this.eventSource = null
-      console.log('Disconnected from search stream')
-    }
-  }
-
-  // Handle incoming messages
-  handleMessage(event) {
-    try {
-      const data = JSON.parse(event.data)
-      console.log('Received search update:', data)
-
-      // Update progress controller if present
-      this.updateProgress(data)
-
-      // Handle different message types
-      if (data.status) {
-        this.handleStatusUpdate(data)
-      }
-
-      if (data.completed) {
-        this.handleCompletion(data)
-      }
-
-    } catch (error) {
-      console.error('Error parsing search update:', error)
-    }
-  }
-
-  // Handle stream errors
-  handleError(event) {
-    if (event?.target?.readyState === EventSource.CLOSED) {
-      console.error('Search stream connection closed', event)
-    } else {
-      console.error('Search stream error:', event)
-    }
-
-    // Attempt to reconnect after a delay
-    setTimeout(() => {
-      console.log('Attempting to reconnect to search stream...')
-      this.disconnectFromStream()
-      this.connectToStream()
-    }, 5000)
-  }
-
-  // Update progress controller
-  updateProgress(data) {
-    const progressController = this.application.getControllerForElementAndIdentifier(
-      this.element,
-      'progress'
-    )
-
-    if (progressController) {
-      progressController.handleStatus(data.status, data)
-    }
-  }
-
-  // Handle status updates
-  handleStatusUpdate(data) {
-    // Update status display
-    if (this.hasStatusTarget) {
-      this.updateStatusContent(data)
-    }
-
-    // Refresh results if sources found
-    if (data.sources_found > 0) {
-      this.refreshResults()
-    }
-  }
-
-  // Handle search completion
-  handleCompletion(data) {
-    console.log('Search completed:', data)
-
-    // Disconnect from stream
-    this.disconnectFromStream()
-
-    // Refresh all content
-    this.refreshResults()
-    this.refreshAiResponse()
-
-    // Show completion message
-    this.showCompletionNotification(data)
-  }
-
-  // Update status content
-  updateStatusContent(data) {
-    // This would be handled by Turbo Streams from the server
-    // For now, just log the update
-    console.log('Status updated:', data)
-  }
-
-  // Refresh search results
+  // Refresh search results by reloading the Turbo Frame
   refreshResults() {
-    if (this.hasResultsTarget) {
-      // Trigger a refresh of the results section
-      // This could be done via Turbo or by making an AJAX request
-      console.log('Refreshing search results...')
-    }
+    if (!this.hasResultsTarget) return
+    Turbo.visit(window.location.href, { frame: "search_results" })
   }
 
-  // Refresh AI response
+  // Refresh AI response by reloading the Turbo Frame
   refreshAiResponse() {
-    if (this.hasAiResponseTarget) {
-      console.log('Refreshing AI response...')
-    }
-  }
-
-  // Show completion notification
-  showCompletionNotification(data) {
-    // Create a temporary notification
-    const notification = document.createElement('div')
-    notification.className = 'fixed top-4 right-4 bg-green-500 text-white px-6 py-3 rounded-lg shadow-lg z-50'
-    notification.innerHTML = `
-      <div class="flex items-center">
-        <span class="text-lg mr-2">✅</span>
-        <span>Search completed! Found ${data.sources_found || 0} sources.</span>
-      </div>
-    `
-
-    document.body.appendChild(notification)
-
-    // Auto-remove after 5 seconds
-    setTimeout(() => {
-      if (notification.parentNode) {
-        notification.remove()
-      }
-    }, 5000)
-  }
-
-  // Manual refresh (for debugging)
-  refresh() {
-    this.disconnectFromStream()
-    this.connectToStream()
-  }
-
-  // Get stream URL
-  get streamUrl() {
-    return this.streamUrlValue || `/searches/${this.searchIdValue}/stream_status`
+    if (!this.hasAiResponseTarget) return
+    Turbo.visit(window.location.href, { frame: "ai_response" })
   }
 }

--- a/app/jobs/stale_search_processing_job.rb
+++ b/app/jobs/stale_search_processing_job.rb
@@ -27,6 +27,7 @@ class StaleSearchProcessingJob < ApplicationJob
             AiResponseGenerationJob.perform_later(search.id)
           else
             search.update!(status: :failed, error_message: "Search timed out with no content extracted")
+            SearchesController.broadcast_status_update(search.id)
           end
         end
       end

--- a/app/jobs/web_scraping_job.rb
+++ b/app/jobs/web_scraping_job.rb
@@ -104,6 +104,7 @@ class WebScrapingJob < ApplicationJob
   def broadcast_scraping_progress(_scraped_data)
     # Only broadcast; do not persist any details on the model
     SearchesController.broadcast_status_update(@search.id)
+    SearchesController.broadcast_results_update(@search.id)
   rescue => e
     Rails.logger.warn "[WebScrapingJob] Broadcast skipped: #{e.message}"
   end

--- a/app/services/scraping/scraping_completion_service.rb
+++ b/app/services/scraping/scraping_completion_service.rb
@@ -63,6 +63,7 @@ class Scraping::ScrapingCompletionService
 
     # Use a new status to prevent re-triggering and show progress
     @search.update!(status: :processing)
+    SearchesController.broadcast_status_update(@search.id)
     AiResponseGenerationJob.perform_later(@search.id)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
   resources :searches, only: [:index, :create, :show] do
     resources :search_results, only: [:index]
     member do
-      get :stream_status, to: 'searches#stream_search_status'
       post :retry_ai_generation
     end
   end


### PR DESCRIPTION
## Summary
- drop SSE streaming and ActionController::Live in SearchesController
- add Turbo-driven refresh helpers in search updates controller
- broadcast status, results, and AI response updates from background jobs

## Testing
- `bundle exec rubocop` *(fails: command not found; Ruby 3.4.5 required)*
- `bundle exec rspec` *(fails: command not found; Ruby 3.4.5 required)*
- `ruby bin/jobs start` *(fails: Ruby version 3.4.5 required)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1a8d8c988324952c4c30d615fdab