### PR TITLE
Add Devise user model and navbar authentication links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ gem 'google-apis-youtube_v3'
 # Performance and Monitoring
 gem 'lograge'
 gem 'rack-cors'
+gem 'devise'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end
+

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,0 +1,14 @@
+<nav class="fixed top-0 left-0 right-0 bg-white shadow">
+  <div class="container mx-auto flex justify-between items-center p-4">
+    <%= link_to 'Gem Search', root_path, class: 'font-bold' %>
+    <div>
+      <% if user_signed_in? %>
+        <%= link_to 'Logout', destroy_user_session_path, method: :delete, class: 'mr-4' %>
+      <% else %>
+        <%= link_to 'Sign up', new_user_registration_path, class: 'mr-4' %>
+        <%= link_to 'Log in', new_user_session_path %>
+      <% end %>
+    </div>
+  </div>
+</nav>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
   </head>
 
   <body>
+    <%= render 'layouts/navbar' %>
     <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>
     </main>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Devise.setup do |config|
+  config.mailer_sender = 'please-change-me@example.com'
+
+  require 'devise/orm/active_record'
+
+  config.case_insensitive_keys = [:email]
+  config.strip_whitespace_keys = [:email]
+
+  config.skip_session_storage = [:http_auth]
+
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  config.reconfirmable = true
+
+  config.expire_all_remember_me_on_sign_out = true
+
+  config.password_length = 6..128
+
+  config.reset_password_within = 6.hours
+
+  config.sign_out_via = :delete
+end
+

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,13 @@
+en:
+  devise:
+    sessions:
+      signed_in: 'Signed in successfully.'
+      signed_out: 'Signed out successfully.'
+      already_signed_out: 'You are already signed out.'
+    registrations:
+      signed_up: 'Welcome! You have signed up successfully.'
+      updated: 'Your account has been updated successfully.'
+      destroyed: 'Bye! Your account has been successfully cancelled.'
+    failure:
+      already_authenticated: 'You are already signed in.'
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
   # Health check
   get "up" => "rails/health#show", as: :rails_health_check
-  
- 
-  
+
+
+  devise_for :users
+
   # Search interface
   resources :searches, only: [:index, :create, :show] do
     resources :search_results, only: [:index]

--- a/db/migrate/20250909120000_devise_create_users.rb
+++ b/db/migrate/20250909120000_devise_create_users.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false
+      # t.string   :unlock_token
+      # t.datetime :locked_at
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_05_100000) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -184,6 +184,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_05_100000) do
     t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
     t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "citations", "search_results"


### PR DESCRIPTION
## Summary
- add Devise gem and user model with authentication fields
- mount Devise routes alongside existing search routes
- render navbar with login and signup links

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rails db:migrate` *(fails: bundler: command not found: rails)*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68c13002d3bc832482e4cbff7b57ed9e