### PR TITLE
Display remaining searches and handle rate limits

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -13,6 +13,15 @@ class SearchesController < ApplicationController
   end
 
   def create
+    if defined?(current_user) && current_user&.respond_to?(:remaining_searches) &&
+       current_user.remaining_searches.to_i <= 0
+      respond_to do |format|
+        format.html { render 'shared/limit_reached', status: :too_many_requests }
+        format.turbo_stream { render 'shared/limit_reached', status: :too_many_requests }
+      end
+      return
+    end
+
     @search = Search.new(search_params)
     @search.user_ip = request.remote_ip
 

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -6,6 +6,20 @@
       <p class="text-lg text-gray-600">Get natural language answers with proper citations from web sources</p>
     </div>
 
+    <% if defined?(current_user) && current_user&.respond_to?(:remaining_searches) %>
+      <div class="text-center mb-4">
+        <span class="text-sm text-gray-600">
+          Remaining searches: <%= current_user.remaining_searches %>
+        </span>
+        <% if current_user.respond_to?(:search_quota) && current_user.search_quota.to_i > 0 &&
+              (current_user.remaining_searches.to_f / current_user.search_quota) < 0.2 %>
+          <% upgrade_link = main_app.respond_to?(:pricing_path) ? main_app.pricing_path : '#' %>
+          <%= link_to 'Upgrade', upgrade_link,
+                      class: 'ml-2 text-sm text-blue-600 hover:text-blue-800 underline' %>
+        <% end %>
+      </div>
+    <% end %>
+
     <!-- Notifications placeholder -->
     <div id="notifications"></div>
 
@@ -171,3 +185,4 @@
     </div>
   </div>
 </div>
+

--- a/app/views/shared/limit_reached.html.erb
+++ b/app/views/shared/limit_reached.html.erb
@@ -1,0 +1,10 @@
+<div class="min-h-screen flex items-center justify-center bg-gray-50">
+  <div class="bg-white rounded-lg shadow p-8 text-center">
+    <h1 class="text-2xl font-semibold mb-4">Search limit reached</h1>
+    <p class="mb-6 text-gray-600">You've used all your available searches.</p>
+    <% upgrade_link = main_app.respond_to?(:pricing_path) ? main_app.pricing_path : '#' %>
+    <%= link_to 'Upgrade', upgrade_link,
+                class: 'bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded' %>
+  </div>
+</div>
+

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe "Searches", type: :request do
     end
   end
 
+  describe "POST /searches when rate limit exceeded" do
+    it "renders limit reached page" do
+      user = double("User", remaining_searches: 0)
+      allow_any_instance_of(SearchesController).to receive(:current_user).and_return(user)
+
+      post "/searches", params: { search: { query: "test" } }
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.body).to include("Search limit reached")
+      expect(response.body).to include("Upgrade")
+    end
+  end
+
   describe "Complete search flow with AI response" do
     let(:search_params) do
       {


### PR DESCRIPTION
## Summary
- show remaining searches on search page and warn near quota with upgrade link
- render dedicated upgrade page when search quota is reached
- guard create action against rate limits and test the behavior

## Testing
- `bundle exec rspec` *(fails: command not found: rspec)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c130479d008324a5493f1509f6a118