### PR TITLE
Add example environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# ------------------------------------------------------------
+# Required credentials
+# ------------------------------------------------------------
+# Required for AI response generation.
+OPENAI_API_KEY=your_openai_api_key
+# Required for web search integration.
+SERPAPI_KEY=your_serpapi_api_key
+
+# ------------------------------------------------------------
+# Required in production for database access
+# ------------------------------------------------------------
+PG_USER=your_production_db_username
+PG_PASSWORD=your_production_db_password
+PG_DATABASE=your_production_db_name
+
+# ------------------------------------------------------------
+# Optional settings (override defaults as needed)
+# ------------------------------------------------------------
+# PostgreSQL host (defaults to 127.0.0.1 in development).
+PGHOST=127.0.0.1
+# PostgreSQL username for local development (defaults to "alessandro").
+PGUSER=your_local_db_username
+# PostgreSQL port (defaults to 5432 in development, 5433 in test).
+PGPORT=5432
+# Size of the Active Record connection pool (defaults to 12 in development).
+RAILS_DB_POOL=12
+
+# Puma / concurrency tuning (all optional).
+RAILS_MAX_THREADS=3
+PORT=3000
+WEB_CONCURRENCY=1
+JOB_CONCURRENCY=2
+SOLID_QUEUE_IN_PUMA=1
+PIDFILE=tmp/pids/server.pid
+
+# Logging and CI helpers.
+RAILS_LOG_LEVEL=info
+CI=false
+
+# Feature flags and service integrations.
+YOUTUBE_API_KEY=your_youtube_api_key
+REPRO_FAST_FALLBACK=0
+URL=http://localhost:3000/up
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*


### PR DESCRIPTION
## Summary
- add a `.env.example` template that documents required API keys and optional environment settings
- adjust `.gitignore` so the example environment file is tracked

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c90920a890832482263f624f794acb